### PR TITLE
Accessibility fixes

### DIFF
--- a/js/adapt-flipper.js
+++ b/js/adapt-flipper.js
@@ -5,7 +5,7 @@ define(function(require) {
 
     var Flipper = ComponentView.extend({
         events: {
-            "click .flipper-container": "onClick"
+            "click .flipper-container, .flipper-button": "onClick"
         },
 
         preRender: function() {
@@ -26,6 +26,7 @@ define(function(require) {
         onImageReady: function() {
             this.setItemVisibility();
             this.setItemHeights();
+            this.setScreenReaderVisibility();
             this.setReadyStatus();
         },
 
@@ -54,6 +55,10 @@ define(function(require) {
             }, this);
         },
 
+        setScreenReaderVisibility: function() {
+            this.$(".flipper-active-item").empty().prepend(this.$(".flipper-item.state-1").clone());
+        },
+
         onClick: function() {
             if (this.locked) return;
 
@@ -77,6 +82,9 @@ define(function(require) {
             setTimeout(function() {
                 $flipper.removeClass("animating");
                 this.locked = false;
+                this.setScreenReaderVisibility();
+                // Set aria live after first item is populated
+                this.$(".flipper-active-item").attr("aria-live", "polite");
             }.bind(this), 600);
         },
 

--- a/less/flipper.less
+++ b/less/flipper.less
@@ -11,6 +11,15 @@
 		-ms-perspective: 1000px;
 		width: 100%;
 		max-width: 100%;
+
+		.screen-reader-only {
+			position: absolute;
+			left: -10000px;
+			top: auto;
+			width: 1px;
+			height: 1px;
+			overflow: hidden;
+		}
 	}
 
 	.flipper {

--- a/templates/flipper.hbs
+++ b/templates/flipper.hbs
@@ -2,7 +2,7 @@
 	{{> component this}}
 	<div class="flipper-widget component-widget">
 		<div class="flipper-container">
-			<div class="flipper stage-0">
+			<div class="flipper stage-0" aria-hidden="true">
 				{{#each _items}}
 					<div class="flipper-item nth-child-{{@index}} state-0">
 						{{#if title}}<div class="flipper-item-title">{{{a11y_text title}}}</div>{{/if}}
@@ -11,9 +11,11 @@
 							{{#if _graphic.src}}<img class="flipper-item-img" src="{{_graphic.src}}" alt="{{_graphic.alt}}">{{/if}}
 						{{/if}}
 						{{#if instruction}}<div class="flipper-item-instruction">{{{a11y_text instruction}}}</div>{{/if}}
+						<button class="flipper-button screen-reader-only" aria-label="Flip to next item"></button>
 					</div>
 				{{/each}}
 			</div>
+			<div class="screen-reader-only flipper-active-item" aria-atomic="true"></div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
This PR aims to make flipper accessible. The following changes have been made:
- Hide usual animated flipper items with aria-hidden
- Push active flipper item to an aria-live region which is visible to screen readers only
- Add a 'Flip to next item' button which is visible to screen readers only so that users know there is an interaction

Fixes #8

Note: I need to put the aria-label text for the flip to next item button in the schema, I wasn't sure where the best location for it would be. Happy to move after discussion

This has been tested by our QA team using the NVDA screen reader on Chrome, IE 11 & Firefox. There are a couple of niggles with Firefox, I'm not sure how severe these issues are in terms of accessibility, crucially all content can be read by the screen reader and the component can be completed.

Issue 1

On Chrome and IE11 the newly pushed item is read out in it's entirety and then the focus is left on the item title, so the user essentially hears the entire item, then they must navigate back through it in order to get to the button to flip to the next item.

On Firefox, the newly pushed item is read out in it's entirety but then the focus is left on the 'next item' button, so if the user wants to read the item again they have to navigate back up through it to get to the top and then back down it again to read it in order.

Issue 2

When navigating through cards in Firefox the focus remains on the 'Next' button. When a user attempts to navigate back over the newly flipped cards text fields, the body text is read before the instruction text on flippers that contain no images. (Note: you can still hear the instruction text when navigating back down)

-Title text is read, press arrowDown, body text is read press arrowDown, instruction text is read press arrowDown.
-Card flips
-Focus is on button, press arrowUp
-body text is read, press arrowDown
-Instruction text is read